### PR TITLE
Add Wikipedia's Filesystem Hierarchy Standard page

### DIFF
--- a/reqreading.html
+++ b/reqreading.html
@@ -39,6 +39,7 @@
       <li><a href="http://www.commitlogsfromlastnight.com/" target="_blank">Commit Logs from Last Night</a>. You are not alone.</li>
       <li>You will learn to sympathize with <a href="http://theprofoundprogrammer.tumblr.com" target="_blank">the Profound Programmer</a>.</li>
       <li>Because Sometimes <a href="http://www.cs.utexas.edu/users/EWD/transcriptions/EWD04xx/EWD498.html" target="_blank">the truth hurts</a></li>
+      <li>If you want to use a computer, you gotta know <a href="http://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard">what's in your filesystem</a></li>
     </ul>
 
     <h2>Section 2: Welcome to Boston<a name="boston"></a></h2>


### PR DESCRIPTION
I didn't know what /tmp was
