### PR TITLE
Fix editorializing about Kanye West

### DIFF
--- a/reqreading.html
+++ b/reqreading.html
@@ -52,7 +52,7 @@
     <h2>Section 3: Other<a name="other"></a></h2>
 
     <ul>
-      <li>YEEEEEEZZZYYYYYY. Listen to all of his albums, starting from the oldest. This will be a journey of growing more disappointed in Kanye West.</li>
+      <li>YEEEEEEZZZYYYYYY. Listen to all of his albums, starting from the oldest. Don't worry, he never makes a song worse than Drunk And Hot Girls</li>
 
     </ul>
 


### PR DESCRIPTION
There is no denying that Graduation is Kanye’s worst album, and MBDTF is a beautiful thing.
